### PR TITLE
Fixed "charms.reactive not found" and unknown charm home.

### DIFF
--- a/reactive/lets_encrypt.py
+++ b/reactive/lets_encrypt.py
@@ -159,9 +159,11 @@ def start_web_service():
 
 
 def configure_periodic_renew():
-    command = ('export CHARM_DIR="{}"; '
-               '/usr/local/bin/charms.reactive set_state lets-encrypt.renew.requested '
-               ''.format(os.environ['CHARM_DIR']))
+    command = (
+        'export CHARM_DIR="{}"; '
+        '/usr/local/bin/charms.reactive '
+        'set_state lets-encrypt.renew.requested '
+        ''.format(os.environ['CHARM_DIR']))
     cron = CronTab(user='root')
     jobRenew = cron.new(
         command=command,

--- a/reactive/lets_encrypt.py
+++ b/reactive/lets_encrypt.py
@@ -1,3 +1,4 @@
+import os
 from subprocess import (
     check_call,
     check_output,
@@ -158,9 +159,12 @@ def start_web_service():
 
 
 def configure_periodic_renew():
+    command = ('export CHARM_DIR="{}"; '
+               '/usr/local/bin/charms.reactive set_state lets-encrypt.renew.requested '
+               ''.format(os.environ['CHARM_DIR']))
     cron = CronTab(user='root')
     jobRenew = cron.new(
-        command='charms.reactive set_state lets-encrypt.renew.requested',
+        command=command,
         comment="Renew Let's Encrypt [managed by Juju]")
     # Twice a day, random minute per certbot instructions
     # https://certbot.eff.org/all-instructions/


### PR DESCRIPTION
I found some issues with the current auto renew functionality:

- A command executed from cron doesn't seem to have `/usr/local/bin` in its path, so we need to use abs path.

- `charms.reactive` doesn't know which charm's states it should change if charm home isn't set, so we have to set it explicitly. *(without charm home, `charms.reactive` defaults to "the charm that is in `CWD`". Another option is to change `CWD` to the charm dir.)*