### PR TITLE
Added dhparams and removed unused state

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,13 @@ Include `layer:lets-encrypt` in your web application charm and set the `fqdn` co
 
 Once the application is registered with Let's Encrypt, the reactive state
 `lets-encrypt.registered` will be set. Then, in your charm, you may obtain the
-path to the certificates and keys with `charms.layer.lets_encrypt.live()`.
+path to the certificates and keys with `charms.layer.lets_encrypt.live()`. This will return a dictionary with the following keys:
+
+ - **`privkey`**: Private key for the certificate. *`SSLCertificateKeyFile` in Apache and `ssl_certificate_key` in NGINX.*
+ - **`fullchain`**: All certificates, including server certificate (aka leaf certificate or end-entity certificate). The server certificate is the first one in this file, followed by any intermediates. *`SSLCertificateFile` in Apache and `ssl_certificate` in NGINX.*
+ - **`dhparam`**: Secure Diffie Hellman parameters as defined by [ietf RFC3526](https://tools.ietf.org/html/rfc3526#page-5) *`SSLOpenSSLConfCmd DHParameters` in Apache and `ssl_dhparam` in NGINX.*
+ - `cert`: The server certificate.
+ - `chain`: The additional intermediate certificates that web browsers will need in order to validate the server certificate.
 
 ## Example: Using with layer:nginx
 

--- a/files/dhparam.pem
+++ b/files/dhparam.pem
@@ -1,0 +1,23 @@
+-----BEGIN DH PARAMETERS-----
+MIICCAKCAgEA///////////JD9qiIWjCNMTGYouA3BzRKQJOCIpnzHQCC76mOxOb
+IlFKCHmONATd75UZs806QxswKwpt8l8UN0/hNW1tUcJF5IW1dmJefsb0TELppjft
+awv/XLb0Brft7jhr+1qJn6WunyQRfEsf5kkoZlHs5Fs9wgB8uKFjvwWY2kg2HFXT
+mmkWP6j9JM9fg2VdI9yjrZYcYvNWIIVSu57VKQdwlpZtZww1Tkq8mATxdGwIyhgh
+fDKQXkYuNs474553LBgOhgObJ4Oi7Aeij7XFXfBvTFLJ3ivL9pVYFxg5lUl86pVq
+5RXSJhiY+gUQFXKOWoqqxC2tMxcNBFB6M6hVIavfHLpk7PuFBFjb7wqK6nFXXQYM
+fbOXD4Wm4eTHq/WujNsJM9cejJTgSiVhnc7j0iYa0u5r8S/6BtmKCGTYdgJzPshq
+ZFIfKxgXeyAMu+EXV3phXWx3CYjAutlG4gjiT6B05asxQ9tb/OD9EI5LgtEgqSEI
+ARpyPBKnh+bXiHGaEL26WyaZwycYavTiPBqUaDS2FQvaJYPpyirUTOjbu8LbBN6O
++S6O/BQfvsqmKHxZR05rwF2ZspZPoJDDoiM7oYZRW+ftH2EpcM7i16+4G912IXBI
+HNAGkSfVsFqpk7TqmI2P3cGG/7fckKbAj030Nck0BjGZ//////////8CAQI=
+-----END DH PARAMETERS-----
+
+"4096-bit MODP Group" from RFC3526, Section 5.
+See: https://tools.ietf.org/html/rfc3526#page-5
+Source: https://bettercrypto.org/static/dhparams/group16.pem
+
+Check these parameters by running
+
+    openssl dhparam -text -noout -in dhparams.pem`
+
+and compare the prime with the prime defined in RFC3526 page 5.

--- a/lib/charms/layer/lets_encrypt.py
+++ b/lib/charms/layer/lets_encrypt.py
@@ -13,4 +13,5 @@ def live():
         'chain': '/etc/letsencrypt/live/%s/chain.pem' % (fqdn),
         'cert': '/etc/letsencrypt/live/%s/cert.pem' % (fqdn),
         'privkey': '/etc/letsencrypt/live/%s/privkey.pem' % (fqdn),
+        'dhparam': '/etc/letsencrypt/dhparam.pem',
     }

--- a/reactive/lets_encrypt.py
+++ b/reactive/lets_encrypt.py
@@ -5,6 +5,7 @@ from subprocess import (
     CalledProcessError
 )
 import random
+from shutil import copyfile
 
 from crontab import CronTab
 
@@ -19,7 +20,8 @@ from charmhelpers.core.hookenv import (
     log,
     config,
     open_port,
-    status_set
+    status_set,
+    charm_dir
 )
 
 from charms.reactive import (
@@ -61,7 +63,6 @@ def register_server():
     configs = config()
     fqdn = configs.get('fqdn')
     if not fqdn:
-        set_state('lets-encrypt.configured')
         return
 
     open_port(80)
@@ -96,6 +97,7 @@ def register_server():
             start_web_service()
     unconfigure_periodic_renew()
     configure_periodic_renew()
+    create_dhparam()
 
 
 @when_all(
@@ -181,6 +183,10 @@ def unconfigure_periodic_renew():
     for job in jobs:
         cron.remove(job)
     cron.write()
+
+
+def create_dhparam():
+    copyfile('{}/files/dhparam.pem'.format(charm_dir()), '/etc/letsencrypt/dhparam.pem')
 
 
 def opened_ports():


### PR DESCRIPTION
# Diffie Hellman parameters

This PR includes secure Diffie Hellman parameters (`dhparams.pem`) for use by upper layers.

These parameters are required for https connections. Most webservers have their own preconfigured dhparams but most of these defaults aren't big enough for current security standards.

It is perfectly fine for Diffie Hellman parameters to be publicly known. In fact, they are transmitted in plaintext during setup of an ssl connection. It is not an issue to use the same parameters on multiple servers. The only concern with DHparams is that they should be secure primes. This PR uses the known-to-be-secure DHparams of [RFC3526](https://tools.ietf.org/html/rfc3526#page-5). `files/dhparams.pem` includes instructions on how to check this.

# Unused `set_state`

This pr also removes an unused and undocumented `set_state('lets-encrypt.configured')`. The name of this state misrepresents when the state gets set. It only gets set if the charm has no `fqdn` config param. So removing this state seems best to avoid confusion.