### PR TITLE
Add support for multiple domain names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # layer-lets-encrypt
 
 # Operating a Charm that uses this layer
@@ -34,6 +35,10 @@ A `contact-email` config option may also be set, for receiving email from Let's 
 
 # Developing a Charm with this layer
 
+## Single certificate
+
+Follow these steps if you only need a single certificate set via the charm config options.
+
 Include `layer:lets-encrypt` in your web application charm and set the `fqdn` config option to automatically obtain a TLS certificate from Let's Encrypt.
 
 Once the application is registered with Let's Encrypt, the reactive state
@@ -46,7 +51,7 @@ path to the certificates and keys with `charms.layer.lets_encrypt.live()`. This 
  - `cert`: The server certificate.
  - `chain`: The additional intermediate certificates that web browsers will need in order to validate the server certificate.
 
-## Example: Using with layer:nginx
+### Example: Using with layer:nginx
 
 Configure layer:lets-encrypt to restart nginx during registration:
 
@@ -88,6 +93,45 @@ Certificate renewal may be disabled by setting the `lets-encrypt.renew.disable`
 state. Set this to prevent the `lets-encrypt` layer from temporarily stopping
 the configured `service-name` during certificate renewal.
 
+
+## Multiple certificates
+
+Include `layer:lets-encrypt` in your charm and use `charms.layer.lets_encrypt.set_requested_certificates(requests)` to create multiple certificates. `requests` has the following format:
+```
+[
+    {
+        'fqdn': ['example.com', 'blog.example.com'], # Covers multiple domains with one certificate
+        'contact_email': ''
+    },
+    {
+        'fqdn': ['sample.com'],
+        'contact_email': 'foo@sample.com'
+    },
+    ...
+]
+```
+Obtain the path to the certificates with `charms.layer.lets_encrypt.live_all()`. This will return a dictionary with the fqdn's as keys and a dictionary with the same keys as described above from `live()`. In case of multiple domains certificate only one fqdn will be present.
+
+Following the example above, `live_all()` could return the following output:
+```
+{
+    'example.com': {
+                       'privkey': '',
+                       'fullchain': '',
+                       'cert': '',
+                       'chain': '',
+                       'dhparam': '',
+                   }
+     'sample.com': {
+                       'privkey': '',
+                       'fullchain': '',
+                       'cert': '',
+                       'chain': '',
+                       'dhparam': '',
+                   }
+}
+```
+ 
 # Caveats
 
 The configured `service-name` will be temporarily stopped while Let's Encrypt

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Include `layer:lets-encrypt` in your charm and use `charms.layer.lets_encrypt.se
     },
     {
         'fqdn': ['sample.com'],
-        'contact_email': 'foo@sample.com'
+        'contact-email': 'foo@sample.com'
     },
     ...
 ]

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ A `contact-email` config option may also be set, for receiving email from Let's 
 
 # Developing a Charm with this layer
 
-## Single certificate
+## Single FQDN
 
-Follow these steps if you only need a single certificate set via the charm config options.
+Follow these steps if you need a single certificate for a single domain name. This is the legacy way of using the lets-encrypt layer where an admin specifies the fqdn using a config option.
 
 Include `layer:lets-encrypt` in your web application charm and set the `fqdn` config option to automatically obtain a TLS certificate from Let's Encrypt.
 
@@ -94,7 +94,9 @@ state. Set this to prevent the `lets-encrypt` layer from temporarily stopping
 the configured `service-name` during certificate renewal.
 
 
-## Multiple certificates
+## Multiple FQDNs
+
+Follow these steps if you need multiple certificates for multiple domain names. The FQDNs need to be set by a higher layer. You can use both methods (single and multiple fqdns) at the same time. If both the config option is set and `set_requested_certificates` is called, then a certificate will be generated for all fqdns.
 
 Include `layer:lets-encrypt` in your charm and use `charms.layer.lets_encrypt.set_requested_certificates(requests)` to create multiple certificates. `requests` has the following format:
 ```

--- a/lib/charms/layer/lets_encrypt.py
+++ b/lib/charms/layer/lets_encrypt.py
@@ -49,7 +49,7 @@ def set_requested_certificates(requests):
     """takes a list of requests which has the following format:
         [{
             'fqdn': ['example.com', 'blog.example.com'],
-            'contact_email': 'example@example.com'
+            'contact-email': 'example@example.com'
         }]
         each list item will request one certificate.
     """


### PR DESCRIPTION
This PR adds a backwards-compatible way to create certificates for multiple domain names.

The domain names are requested using the `set_requested_certificates` method, and a `live_all` method to get all generated certificates. The config value and `live` still work exactly the same. Using both config value and `set_requested_certificates` at the same time is even supported.

Example of a layer using this functionality to create a https reverseproxy: https://github.com/tengu-team/layer-ssl-termination-proxy

So, what do you think?
