### PR TITLE
Fix certificate renew

### DIFF
--- a/lib/charms/layer/lets_encrypt.py
+++ b/lib/charms/layer/lets_encrypt.py
@@ -26,7 +26,7 @@ def live():
 def live_all():
     """live_all returns a dict containing per fqdn the paths of certificate and
     key files.
-    
+
     Multiple domain certificates will only return one dict using one of the fqdn as key."""
     requests = unitdata.kv().get('certificate.requests', [])
     if not requests:
@@ -57,4 +57,5 @@ def set_requested_certificates(requests):
         return
     unitdata.kv().set('certificate.requests', requests)
     remove_state('lets-encrypt.registered')
+    remove_state('lets-encrypt.certificate-requested') # reset so handler will rerun even if it already ran
     set_state('lets-encrypt.certificate-requested')

--- a/reactive/lets_encrypt.py
+++ b/reactive/lets_encrypt.py
@@ -1,11 +1,12 @@
+#!/usr/bin/env python3
 import os
-import shutil
 from subprocess import (
     check_output,
     CalledProcessError,
     STDOUT
 )
 import random
+import shutil
 from shutil import copyfile
 
 from crontab import CronTab

--- a/reactive/lets_encrypt.py
+++ b/reactive/lets_encrypt.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from subprocess import (
     check_output,
     CalledProcessError,
@@ -167,9 +168,11 @@ def start_web_service():
 def configure_periodic_renew():
     command = (
         'export CHARM_DIR="{}"; '
-        '/usr/local/bin/charms.reactive '
+        '{} '
         'set_state lets-encrypt.renew.requested '
-        ''.format(os.environ['CHARM_DIR']))
+        ''.format(
+            os.environ['CHARM_DIR'],
+            shutil.which("charms.reactive")))
     cron = CronTab(user='root')
     jobRenew = cron.new(
         command=command,


### PR DESCRIPTION
Due to a change in the location of the `charms.reactive` binary, the automatic renew functionality is broken in the current version of this layer.

This fixes the issue in a future proof way: `which` is used to get the full path of the `charms.reactive` binary.