### PR TITLE
Bionic support

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Following the example above, `live_all()` could return the following output:
 The configured `service-name` will be temporarily stopped while Let's Encrypt
 registers and renews with the "standalone" method.
 
-This layer is only supported on xenial. If deployed on earlier series, this
+This layer is only supported on xenial and above. If deployed on earlier series, this
 layer does nothing.
 
 This layer requires agreement to the ISRG Let's Encrypt terms of service in

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,4 +1,5 @@
 series:
   - xenial
+  - bionic
 terms:
   - isrg-lets-encrypt

--- a/reactive/lets_encrypt.py
+++ b/reactive/lets_encrypt.py
@@ -42,8 +42,8 @@ from charms import apt
 
 @when_not('apt.installed.letsencrypt')
 def check_version_and_install():
-    series = lsb_release()['DISTRIB_CODENAME']
-    if not series >= 'xenial':
+    series = lsb_release()['DISTRIB_RELEASE']
+    if not series >= '16.04':
         log('letsencrypt not supported on series >= %s' % (series))
         status_set('blocked', "Unsupported series < Xenial")
         return


### PR DESCRIPTION
Lets encrypt only installs on xenial (blocks on bionic). This PR allows releases >= Xenial.